### PR TITLE
Add GitHub action "Register Package"

### DIFF
--- a/.github/workflows/register.yml
+++ b/.github/workflows/register.yml
@@ -1,0 +1,14 @@
+name: Register Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to register or component to bump
+        required: true
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/RegisterAction@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This file is generated by [PkgTemplates.jl](https://invenia.github.io/PkgTemplates.jl/dev/user/#PkgTemplates.RegisterAction).
This action can make releasing a new version very easy:
<img width="1685" alt="image" src="https://user-images.githubusercontent.com/25192197/163901093-d00afa21-a386-4c88-a3cb-c03203a40f72.png">
Just click "Run Workflow", type your new version and click confirm, done! A new version will be registered on Julia's `General` registry.