### PR TITLE
feat: ignore `LineNumberNode`

### DIFF
--- a/src/LazyStartup.jl
+++ b/src/LazyStartup.jl
@@ -25,12 +25,15 @@ function match_expr(pattern::Symbol, ex::Expr)
 end
 match_expr(pattern::Expr, ex) = false
 function match_expr(pattern::Expr, ex::Expr)
+    # test current expression
     ex_match = false
     if pattern.head === ex.head
         ex_match = true
         for sub_p in pattern.args
+            sub_p isa LineNumberNode && continue
             arg_match = false
             for arg in ex.args
+                arg isa LineNumberNode && continue
                 if match_expr(sub_p, arg)
                     arg_match = true
                     break
@@ -43,6 +46,7 @@ function match_expr(pattern::Expr, ex::Expr)
         end
     end
     ex_match && return true
+    # test sub expressions of ex
     for arg in ex.args
         match_expr(pattern, arg) && return true
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,7 @@ end
                 show(IOContext(stdout, :compact => false, :limit => false), "text/plain", $(esc(expr)))
             end
         end
+        @lazy_startup using Cthulhu @descend() @descend_code_typed() @descend_code_warntype()
         @static if VERSION >= v"1.6"
             @lazy_startup import Foo as Bar
             @lazy_startup import Foo: h as h1
@@ -92,7 +93,7 @@ end
         @test check_startup(Expr(:toplevel, :x)).args[1] == :x
         @test all(!is_evaled, STARTUPS)
         test_exprs = [
-            :f, :A, :(using Test), :g, :Foo, :h, :(@btime 1), :(u"bohr"), :(@showall 1)
+            :f, :A, :(using Test), :g, :Foo, :h, :(@btime 1), :(u"bohr"), :(@showall 1), :(@descend f())
         ]
         @static if VERSION >= v"1.6"
             push!(test_exprs, :Bar, :h1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,7 @@ end
         @lazy_startup import Foo: h
         # issue #4
         @lazy_startup using BenchmarkTools Symbol("@btime")
+        @lazy_startup using Unitful @u_str
         @lazy_startup macro showall(expr)
             return quote
                 show(IOContext(stdout, :compact => false, :limit => false), "text/plain", $(esc(expr)))
@@ -90,7 +91,7 @@ end
         @test check_startup(Expr(:toplevel, :x)).args[1] == :x
         @test all(!is_evaled, STARTUPS)
         test_exprs = [
-            :f, :A, :(using Test), :g, :Foo, :h, :(@btime 1), :(@showall 1)
+            :f, :A, :(using Test), :g, :Foo, :h, :(@btime 1), :(u"bohr"), :(@showall 1)
         ]
         @static if VERSION >= v"1.6"
             push!(test_exprs, :Bar, :h1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,9 +22,12 @@ end
         @test match_expr(:x, :(x + y))
         @test match_expr(:y, :(f(x) + g(y)))
         @test match_expr(:g, :(f(x) + g(y)))
+        @test match_expr(:(@test), :(@test x == y))
         @test !match_expr(:x, :y)
         @test !match_expr(:x, :(g(y)))
         @test !match_expr(:f, :(g(y)))
+        @test !match_expr(:(f(*, *)), :(f(x)))
+        @test !match_expr(:(@btime *, *), :(@btime x))
         @test match_expr(:(using *), :(using Test))
         @test match_expr(:(using *), :(using Test, LazyStartup))
         @test match_expr(:(using *), quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,8 +26,6 @@ end
         @test !match_expr(:x, :y)
         @test !match_expr(:x, :(g(y)))
         @test !match_expr(:f, :(g(y)))
-        @test !match_expr(:(f(*, *)), :(f(x)))
-        @test !match_expr(:(@btime *, *), :(@btime x))
         @test match_expr(:(using *), :(using Test))
         @test match_expr(:(using *), :(using Test, LazyStartup))
         @test match_expr(:(using *), quote


### PR DESCRIPTION
Ignore `LineNumberNode` in pattern, it's helpful to match macro call.


Examples:
```julia
@lazy_startup using Foo @foo # match @foo ...
@lazy_startup using Bar @bar() @baz() # match @bar or @baz
```