### PR TITLE
Initialize with `lazy_startup_init!()` and force startup code to be evaluated in top-level scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ and can be delayed by `@lazy_startup`:
 ```julia
 using LazyStartup # NOTE: this package must be loaded in startup.jl
 
+atreplinit() do repl
+  lazy_startup_init!() # NOTE: this function must be called in atreplinit and after `REPL.ipython_mode!`
+end
+
 @lazy_startup using Revise import * using * include(*)
 
 @lazy_startup function f()

--- a/src/LazyStartup.jl
+++ b/src/LazyStartup.jl
@@ -3,7 +3,7 @@ module LazyStartup
 import REPL
 using Base.Meta: isexpr
 
-export @lazy_startup
+export @lazy_startup, lazy_startup_init!
 
 mutable struct Startup{F}
     ex::Expr
@@ -162,8 +162,27 @@ macro lazy_startup(ex, ps...)
     return startup
 end
 
-function __init__()
-    push!(REPL.repl_ast_transforms, check_startup)
+__current_ast_transforms() =
+    isdefined(Base, :active_repl_backend) ? Base.active_repl_backend.ast_transforms :
+    REPL.repl_ast_transforms
+
+"""
+    lazy_startup_init!()
+
+Initialize the REPL to use `LazyStartup`. This should be called in `~/.julia/config/startup.jl`.
+Like this:
+
+```julia
+using LazyStartup
+
+atreplinit() do repl
+    lazy_startup_init!()
 end
+```
+
+!!! Note
+    If you are using `ipython` mode, you should call `REPL.ipython_mode!(repl)` before`lazy_startup_init!()`.
+"""
+lazy_startup_init!() = push!(__current_ast_transforms(), check_startup)
 
 end # module

--- a/src/LazyStartup.jl
+++ b/src/LazyStartup.jl
@@ -115,15 +115,16 @@ const STARTUPS = []
 
 function check_startup(ex)
     isempty(STARTUPS) && return ex
-    startup_block = Expr(:block)
+    startup_block = Expr(:toplevel)
     for s in STARTUPS
         if should_eval(ex, s)
             push!(startup_block.args, s.ex)
             s.evaled = true
         end
     end
-    isempty(startup_block.args) || pushfirst!(ex.args, startup_block)
-    return ex
+    isempty(startup_block.args) && return ex
+    push!(startup_block.args, ex)
+    return startup_block
 end
 
 function collect_pattern(ps)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,7 +100,7 @@ end
         end
         @test length(STARTUPS) == length(test_exprs)
         for expr in test_exprs
-            @test check_startup(Expr(:toplevel, expr)).args[1].args[1] == STARTUPS[1].ex
+            @test check_startup(Expr(:toplevel, expr)).args[1] == STARTUPS[1].ex
             @test is_evaled(STARTUPS[1])
             popfirst!(STARTUPS)
             @test all(!is_evaled, STARTUPS)


### PR DESCRIPTION
Fixes #11