### PR TITLE
fix: check if `active_repl_backend` is nothing

### DIFF
--- a/src/LazyStartup.jl
+++ b/src/LazyStartup.jl
@@ -163,8 +163,11 @@ macro lazy_startup(ex, ps...)
 end
 
 __current_ast_transforms() =
-    isdefined(Base, :active_repl_backend) ? Base.active_repl_backend.ast_transforms :
-    REPL.repl_ast_transforms
+    if isdefined(Base, :active_repl_backend) && Base.active_repl_backend !== nothing
+        Base.active_repl_backend.ast_transforms
+    else
+        REPL.repl_ast_transforms
+    end
 
 """
     lazy_startup_init!()


### PR DESCRIPTION
On julia 1.12, the `Base.active_repl_backend` is set to nothing.

Fixes #13 